### PR TITLE
implement start/end management

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,28 @@ To run batty, it requires root privileges:
 
 #### Option A - Use CLI
 
+View current battery charge thresholds:
+
+```bash
+sudo ~/.cargo/bin/batty
+```
+
+Set the end threshold (default kind):
+
 ```bash
 sudo ~/.cargo/bin/batty --value 80
+```
+
+Set the start threshold:
+
+```bash
+sudo ~/.cargo/bin/batty --value 40 --kind start
+```
+
+Or use the short flags:
+
+```bash
+sudo ~/.cargo/bin/batty -v 40 -k start
 ```
 
 Works immediately. Keep in mind it is not persistent yet.
@@ -50,4 +70,10 @@ Works immediately. Keep in mind it is not persistent yet.
 sudo ~/.cargo/bin/batty --tui
 ```
 
-This will give you write access in the TUI
+This will give you write access in the TUI.
+
+Controls:
+- Use ↑/↓ or +/- to adjust thresholds
+- Use j/k to switch between start and end threshold
+- Press Enter to save both thresholds
+- Press q to quit


### PR DESCRIPTION
Adds support for managing both start and end battery charge thresholds.

  ### Changes

  - Added `--kind` flag to specify which threshold kind to set (start or end)
  - CLI now displays both start and end thresholds when run without arguments
  - TUI updated to edit both thresholds simultaneously:
    - Use `j`/`k` to switch between start and end threshold
    - Both values are saved together when pressing Enter
    - Validation prevents start threshold from exceeding end threshold
  - Updated README with usage examples for both thresholds

  ### Example usage

  ```bash
  # Set end threshold (default)
  sudo batty --value 80

  # Set start threshold
  sudo batty --value 40 --kind start