### PR TITLE
Fix/missing threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.1] - 2025-10-30
+### Changed
+-  Fixed error on writing to start threshold if path not available
+
 ## [0.4.0] - 2025-10-22
 ### Added
 - Added battery statistics display in TUI header

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "batty"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "batty"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Nico Estrada <estradanicolas@gmail.com>", "Gabriel Vincent"]
 edition = "2021"
 description = "Battery Health Tool for Linux"

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -30,7 +30,11 @@ impl Thresholds {
         let start_path = get_path_for_kind(base_path, &ThresholdKind::Start);
         let end_path = get_path_for_kind(base_path, &ThresholdKind::End);
 
-        let start = read_threshold(&start_path)?;
+        let start = match read_threshold(&start_path) {
+            Ok(value) => value,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => 0,
+            Err(err) => return Err(err),
+        };
         let end = read_threshold(&end_path)?;
 
         Ok(Self { start, end })
@@ -40,7 +44,9 @@ impl Thresholds {
         let start_path = get_path_for_kind(base_path, &ThresholdKind::Start);
         let end_path = get_path_for_kind(base_path, &ThresholdKind::End);
 
-        write_threshold(&start_path, self.start)?;
+        if start_path.exists() {
+            write_threshold(&start_path, self.start)?;
+        }
         write_threshold(&end_path, self.end)?;
 
         Ok(())


### PR DESCRIPTION
Was getting error when trying to set a start threshold, so added a check to validate path exists if user wants to only set end threshold if path exists.