### PR TITLE
Add charge based acpi support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Added support for charge-based ACPI battery attributes (charge_now, charge_full)
+- Fixed batty failing on systems that expose charge-based instead of energy-based attributes
+- Battery reader now automatically detects and uses either energy (µWh) or charge (µAh) attributes
+
 ## [0.4.2] - 2025-11-06
 ### Added
 - Added battery health percentage display in TUI header


### PR DESCRIPTION
## Summary

Fixes batty failing on systems with charge-based ACPI battery attributes. Some laptop batteries report `charge_now`/`charge_full` (µAh) instead of `energy_now`/`energy_full` (µWh) depending on their firmware's power_unit setting. This causes batty to crash with "No such file or directory" errors on affected systems.

## Changes

- Added attribute probing that tries both energy-based and charge-based file names
- Energy attributes are tried first (backward compatible with existing systems)
- Falls back to charge attributes if energy files don't exist
- Enhanced error messages show which files were attempted
- Added module documentation explaining dual-mode support

## Technical Details

The Linux kernel ACPI battery driver exposes different sysfs attributes based on the battery firmware:
- **Energy mode** (µWh): `energy_now`, `energy_full`, `energy_full_design`
- **Charge mode** (µAh): `charge_now`, `charge_full`, `charge_full_design`

Batty's percentage calculations already work with either unit since they use ratios. This PR simply adds the ability to detect and read from either attribute set.